### PR TITLE
fix(ci): make gh-pages ci run even on first commit

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/gh-pages.yml
@@ -5,16 +5,6 @@ permissions:
   contents: write
 "on":
   push:
-    paths:
-      - ".github/workflows/gh-pages.yml"
-      - ".gitignore"
-      - ".gitattributes"
-      - "CHANGELOG.adoc"
-      - "CODE_OF_CONDUCT.md"
-      - "CONTRIBUTING.adoc"
-      - "DEVELOPMENT.adoc"
-      - "LICENSE"
-      - "README.orig.adoc"
 
 jobs:
   gh-pages:


### PR DESCRIPTION
as per https://github.com/JonasPammer/cookiecutter-github-action-typescript/issues/4